### PR TITLE
实现代码分离:model 添加subScript模块

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "chai": "^2.3.0",
     "coffee-script": "^1.12.7",
+    "grunt": "^1.0.4",
     "grunt-cola-ui-build": "git+https://github.com/Cola-Org/grunt-cola-ui-build.git",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-coffee": "^0.13.0",

--- a/src/core/dom-template.yaml
+++ b/src/core/dom-template.yaml
@@ -19,6 +19,12 @@ methods:
       });
       </code>
     arguments:
+      - name: subScript
+        type: Array
+        label: 同作用域脚本路径
+        description: |
+          在很多情况下，一个js并不能满足开发需要，Cola可以提供一个同作用域model;
+          它们和subView的作用相似，当前脚本为父级,可以在页面模板方法表达式中通过"R:xxxxx"直接获取子级的action，subScript可以获取父级作用域下的属性或者方法。
       - name: modelName
         type: string
         label: Model的名称

--- a/src/core/model.coffee
+++ b/src/core/model.coffee
@@ -208,7 +208,14 @@ class cola.Model extends cola.Scope
 			store = @action
 			if arguments.length is 1
 				if typeof name is "string"
-					return @_getAction(name) or cola.defaultAction[name]
+					if name.indexOf("R:") is 0
+						name = name.substr(2);
+						if @_childScopes && @_childScopes.constructor.name is "Array"
+							childrens = @_childScopes;
+							for children in childrens when children.action isnt null
+								return children.action[a] for action in children.action when action is a
+					else
+						return @_getAction(name) or cola.defaultAction[name]
 				else if name and typeof name is "object"
 					config = name
 					for n, a of config


### PR DESCRIPTION
大多数情况下，一个页面一个js并不能满足开发现状，这样会造成每个javascrip的中的代码量很高，那么添加一个同等作用域的model来拆分一些脚本代码,该方案适用于subview下

同时api打包存在一点问题


```shell
grunt api
Running "yamlToDoc:api" (yamlToDoc) task
Warning: Cannot read property 'length' of undefined Use --force to continue.

Aborted due to warnings.
```